### PR TITLE
Add :introduce direct link entry and verify recovery flashability

### DIFF
--- a/data/supported-devices/device_template.yml
+++ b/data/supported-devices/device_template.yml
@@ -19,13 +19,13 @@
       link:
       text:
       filename:
-      direct_link: #link that is directly downloadable ,mainly for the installer.
+      direct_download_link: #link that is directly downloadable ,mainly for the installer.
       is_recovery_flashable: # to know if the file is recovery flashable ,mainly for the installer.
   vendor_zip:
       link:
       text:
       filename:
-      direct_link:
+      direct_download_link:
       is_recovery_flashable:
   vendor_image:
       link:
@@ -36,24 +36,24 @@
       link:
       text:
       filename:
-      direct_link:
+      direct_download_link:
   dtbo:
       link:
       text:
       filename:
-      direct_link:
+      direct_download_link:
   recovery:
       name:
       link:
       text: 
       filename:
-      direct_link:
+      direct_download_link:
       must_flash:
   adaptation:
       link:
       text:
       filename:
-      direct_link:
+      direct_download_link:
   statuspage:
   contact:
       text:

--- a/data/supported-devices/device_template.yml
+++ b/data/supported-devices/device_template.yml
@@ -19,32 +19,41 @@
       link:
       text:
       filename:
+      direct_link: #link that is directly downloadable ,mainly for the installer.
+      is_recovery_flashable: # to know if the file is recovery flashable ,mainly for the installer.
   vendor_zip:
       link:
       text:
       filename:
+      direct_link:
+      is_recovery_flashable:
   vendor_image:
       link:
       text:
       filename:
+      direct_link:
   boot:
       link:
       text:
       filename:
+      direct_link:
   dtbo:
       link:
       text:
       filename:
+      direct_link:
   recovery:
       name:
       link:
       text: 
       filename:
+      direct_link:
       must_flash:
   adaptation:
       link:
       text:
       filename:
+      direct_link:
   statuspage:
   contact:
       text:


### PR DESCRIPTION
This MR is geared towards an installer
- direct_link entry would mean and installer could use tools like "wget "  to download files
- is_recovery_flashable entry would help installer differentiate a recovery flashable zip from a zipped img file.

Please approve this MR.

in my opinion this seems necessary to finish [ this zenity  GUI based installer ](https://github.com/mathew-dennis/droidian-violet-guide/blob/main/installer.sh) that I am working on. or effectively any installer the community developes.