### PR TITLE
move lavenders images to adaptation

### DIFF
--- a/data/supported-devices/devices/xiaomi_lavender.yml
+++ b/data/supported-devices/devices/xiaomi_lavender.yml
@@ -31,17 +31,17 @@ vendor_image:
   text:
   filename:
 boot:
-  link: https://github.com/droidian-lavender/kernel-xiaomi-lavender/releases/download/images/boot.img
-  text: Boot image
-  filename: boot.img
+  link:
+  text:
+  filename:
 dtbo:
   link:
   text:
   filename:
 vbmeta:
-    link: https://github.com/droidian-lavender/kernel-xiaomi-lavender/releases/download/images/vbmeta.img
-    text: vbmeta image
-    filename: vbmeta.img
+    link:
+    text:
+    filename:
 recovery:
   name: TWRP
   link: https://twrp.me/xiaomi/xiaomiredminote7.html


### PR DESCRIPTION
boot image for lavender has been moved into the adaptation package itself so does not need to be flashed separately